### PR TITLE
Implement `fmt.Formatter`

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -35,18 +36,7 @@ func main() {
 		log.Fatal(err)
 	}
 	res.Body.Close()
-	end := time.Now()
+	result.End(time.Now())
 
-	log.Printf("DNS lookup: %d ms", int(result.DNSLookup/time.Millisecond))
-	log.Printf("TCP connection: %d ms", int(result.TCPConnection/time.Millisecond))
-	log.Printf("TLS handshake: %d ms", int(result.TLSHandshake/time.Millisecond))
-	log.Printf("Server processing: %d ms", int(result.ServerProcessing/time.Millisecond))
-	log.Printf("Content transfer: %d ms", int(result.ContentTransfer(time.Now())/time.Millisecond))
-	log.Println()
-
-	log.Printf("Name Lookup: %d ms", int(result.NameLookup/time.Millisecond))
-	log.Printf("Connect: %d ms", int(result.Connect/time.Millisecond))
-	log.Printf("Pre Transfer: %d ms", int(result.Pretransfer/time.Millisecond))
-	log.Printf("Start Transfer: %d ms", int(result.StartTransfer/time.Millisecond))
-	log.Printf("Total: %d ms", int(result.Total(end)/time.Millisecond))
+	fmt.Printf("%+v\n", result)
 }

--- a/httpstat.go
+++ b/httpstat.go
@@ -3,9 +3,13 @@
 package httpstat
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"net"
 	"net/http/httptrace"
+	"strings"
 	"time"
 )
 
@@ -16,18 +20,22 @@ type Result struct {
 	TCPConnection    time.Duration
 	TLSHandshake     time.Duration
 	ServerProcessing time.Duration
+	contentTransfer  time.Duration
 
 	// The followings are timeline of reuqest
 	NameLookup    time.Duration
 	Connect       time.Duration
 	Pretransfer   time.Duration
 	StartTransfer time.Duration
+	total         time.Duration
 
 	t0 time.Time
 	t1 time.Time
 	t2 time.Time
 	t3 time.Time
 	t4 time.Time
+
+	t5 time.Time // need to be provided from outside
 
 	// isTLS is true when connection seems to use TLS
 	isTLS bool
@@ -36,19 +44,19 @@ type Result struct {
 	isReused bool
 }
 
-func (r *Result) durations(t time.Time) map[string]time.Duration {
+func (r *Result) durations() map[string]time.Duration {
 	return map[string]time.Duration{
 		"DNSLookup":        r.DNSLookup,
 		"TCPConnection":    r.TCPConnection,
 		"TLSHandshake":     r.TLSHandshake,
 		"ServerProcessing": r.ServerProcessing,
-		"ContentTransfer":  r.ContentTransfer(t),
+		"ContentTransfer":  r.contentTransfer,
 
 		"NameLookup":    r.NameLookup,
 		"Connect":       r.Connect,
 		"Pretransfer":   r.Connect,
 		"StartTransfer": r.StartTransfer,
-		"Total":         r.Total(t),
+		"Total":         r.total,
 	}
 }
 
@@ -64,6 +72,70 @@ func (r *Result) ContentTransfer(t time.Time) time.Duration {
 // time must be time after read body (go-httpstat can not detect that time).
 func (r *Result) Total(t time.Time) time.Duration {
 	return t.Sub(r.t0)
+}
+
+// End sets the time when read is done.
+func (r *Result) End(t time.Time) {
+	r.t5 = t
+	r.contentTransfer = r.t5.Sub(r.t4)
+	r.total = r.t5.Sub(r.t0)
+}
+
+func (r Result) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			var buf bytes.Buffer
+			fmt.Fprintf(&buf, "DNS lookup:        %4d ms\n",
+				int(r.DNSLookup/time.Millisecond))
+			fmt.Fprintf(&buf, "TCP connection:    %4d ms\n",
+				int(r.TCPConnection/time.Millisecond))
+			fmt.Fprintf(&buf, "TLS handshake:     %4d ms\n",
+				int(r.TLSHandshake/time.Millisecond))
+			fmt.Fprintf(&buf, "Server processing: %4d ms\n",
+				int(r.ServerProcessing/time.Millisecond))
+
+			if !r.t5.IsZero() {
+				fmt.Fprintf(&buf, "Content transfer:  %4d ms\n\n",
+					int(r.contentTransfer/time.Millisecond))
+			} else {
+				fmt.Fprintf(&buf, "Content transfer:  %4s ms\n\n", "-")
+			}
+
+			fmt.Fprintf(&buf, "Name Lookup:    %4d ms\n",
+				int(r.NameLookup/time.Millisecond))
+			fmt.Fprintf(&buf, "Connect:        %4d ms\n",
+				int(r.Connect/time.Millisecond))
+			fmt.Fprintf(&buf, "Pre Transfer:   %4d ms\n",
+				int(r.Pretransfer/time.Millisecond))
+			fmt.Fprintf(&buf, "Start Transfer: %4d ms\n",
+				int(r.StartTransfer/time.Millisecond))
+
+			if !r.t5.IsZero() {
+				fmt.Fprintf(&buf, "Total:          %4d ms\n",
+					int(r.total/time.Millisecond))
+			} else {
+				fmt.Fprintf(&buf, "Total:          %4s ms\n", "-")
+			}
+			io.WriteString(s, buf.String())
+			return
+		}
+
+		fallthrough
+	case 's', 'q':
+		d := r.durations()
+		list := make([]string, 0, len(d))
+		for k, v := range d {
+			// Handle when End function is not called
+			if (k == "ContentTransfer" || k == "Total") && r.t5.IsZero() {
+				list = append(list, fmt.Sprintf("%s: - ms", k))
+				continue
+			}
+			list = append(list, fmt.Sprintf("%s: %d ms", k, v/time.Millisecond))
+		}
+		io.WriteString(s, strings.Join(list, ", "))
+	}
+
 }
 
 // WithHTTPStat is a wrapper of httptrace.WithClientTrace. It records the


### PR DESCRIPTION
Implement `fmt.Formatter` to display all stat information. Now you don't need to write each stats one by one. Just use  `%+v` and it outputs all information,  

```golang
fmt.Printf("%+v\n", result)
```

Output,

```bash
DNS lookup:         461 ms
TCP connection:     163 ms
TLS handshake:      427 ms
Server processing:  165 ms
Content transfer:     0 ms

Name Lookup:     461 ms
Connect:         624 ms
Pre Transfer:   1052 ms
Start Transfer: 1218 ms
Total:          1218 ms
```