### PR TITLE
Use go1.8 TLS hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: go
 
 go:
   - 1.7.5
-  - 1.8rc3
+  - 1.8
+  - 1.8.1
   - tip
 
 os:

--- a/go18.go
+++ b/go18.go
@@ -1,0 +1,121 @@
+// +build go1.8
+
+package httpstat
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http/httptrace"
+	"time"
+)
+
+// End sets the time when reading response is done.
+// This must be called after reading response body.
+func (r *Result) End(t time.Time) {
+	r.trasferDone = t
+	r.t5 = t // for Formatter
+
+	// This means result is empty (it does nothing).
+	// Skip setting value(contentTransfer and total will be zero).
+	if r.dnsStart.IsZero() {
+		return
+	}
+
+	r.contentTransfer = r.trasferDone.Sub(r.transferStart)
+	r.total = r.trasferDone.Sub(r.dnsStart)
+}
+
+func withClientTrace(ctx context.Context, r *Result) context.Context {
+	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		DNSStart: func(i httptrace.DNSStartInfo) {
+			r.dnsStart = time.Now()
+		},
+
+		DNSDone: func(i httptrace.DNSDoneInfo) {
+			r.dnsDone = time.Now()
+
+			r.DNSLookup = r.dnsDone.Sub(r.dnsStart)
+			r.NameLookup = r.dnsDone.Sub(r.dnsStart)
+		},
+
+		ConnectStart: func(_, _ string) {
+			r.tcpStart = time.Now()
+
+			// When connecting to IP (When no DNS lookup)
+			if r.dnsStart.IsZero() {
+				r.dnsStart = r.tcpStart
+				r.dnsDone = r.tcpStart
+			}
+		},
+
+		ConnectDone: func(network, addr string, err error) {
+			r.tcpDone = time.Now()
+
+			r.TCPConnection = r.tcpDone.Sub(r.tcpStart)
+			r.Connect = r.tcpDone.Sub(r.dnsStart)
+		},
+
+		TLSHandshakeStart: func() {
+			r.isTLS = true
+			r.tlsStart = time.Now()
+		},
+
+		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+			r.tlsDone = time.Now()
+
+			r.TLSHandshake = r.tlsDone.Sub(r.tlsStart)
+			r.Pretransfer = r.tlsDone.Sub(r.dnsStart)
+		},
+
+		GotConn: func(i httptrace.GotConnInfo) {
+			// Handle when keep alive is used and connection is reused.
+			// DNSStart(Done) and ConnectStart(Done) is skipped
+			if i.Reused {
+				r.isReused = true
+			}
+		},
+
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			r.serverStart = time.Now()
+
+			// When client doesn't use DialContext or using old (before go1.7) `net`
+			// pakcage, DNS/TCP/TLS hook is not called.
+			if r.dnsStart.IsZero() && r.tcpStart.IsZero() {
+				now := r.serverStart
+
+				r.dnsStart = now
+				r.dnsDone = now
+				r.tcpStart = now
+				r.tcpDone = now
+			}
+
+			// When connection is re-used, DNS/TCP/TLS hook is not called.
+			if r.isReused {
+				now := r.serverStart
+
+				r.dnsStart = now
+				r.dnsDone = now
+				r.tcpStart = now
+				r.tcpDone = now
+				r.tlsStart = now
+				r.tlsDone = now
+			}
+
+			if r.isTLS {
+				return
+			}
+
+			r.TLSHandshake = r.tcpDone.Sub(r.tcpDone)
+			r.Pretransfer = r.Connect
+		},
+
+		GotFirstResponseByte: func() {
+			r.serverDone = time.Now()
+
+			r.ServerProcessing = r.serverDone.Sub(r.serverStart)
+			r.StartTransfer = r.serverDone.Sub(r.dnsStart)
+
+			r.transferStart = r.serverDone
+		},
+	})
+}

--- a/httpstat.go
+++ b/httpstat.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
-	"net/http/httptrace"
 	"strings"
 	"time"
 )
@@ -34,8 +32,18 @@ type Result struct {
 	t2 time.Time
 	t3 time.Time
 	t4 time.Time
-
 	t5 time.Time // need to be provided from outside
+
+	dnsStart      time.Time
+	dnsDone       time.Time
+	tcpStart      time.Time
+	tcpDone       time.Time
+	tlsStart      time.Time
+	tlsDone       time.Time
+	serverStart   time.Time
+	serverDone    time.Time
+	transferStart time.Time
+	trasferDone   time.Time // need to be provided from outside
 
 	// isTLS is true when connection seems to use TLS
 	isTLS bool
@@ -74,22 +82,7 @@ func (r *Result) Total(t time.Time) time.Duration {
 	return t.Sub(r.t0)
 }
 
-// End sets the time when reading response is done.
-// This must be called after reading response body.
-func (r *Result) End(t time.Time) {
-	r.t5 = t
-
-	// This means result is empty (it does nothing).
-	// Skip setting value(contentTransfer and total will be zero).
-	if r.t0.IsZero() {
-		return
-	}
-
-	r.contentTransfer = r.t5.Sub(r.t4)
-	r.total = r.t5.Sub(r.t0)
-}
-
-// Format implements fmt.Formatter interface.
+// Format formats stats result.
 func (r Result) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
@@ -150,90 +143,5 @@ func (r Result) Format(s fmt.State, verb rune) {
 // WithHTTPStat is a wrapper of httptrace.WithClientTrace. It records the
 // time of each httptrace hooks.
 func WithHTTPStat(ctx context.Context, r *Result) context.Context {
-	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
-		GetConn: func(hostPort string) {
-			_, port, err := net.SplitHostPort(hostPort)
-			if err != nil {
-				return
-			}
-
-			// Heuristic way to detect
-			if port == "443" {
-				r.isTLS = true
-			}
-		},
-
-		DNSStart: func(i httptrace.DNSStartInfo) {
-			r.t0 = time.Now()
-		},
-		DNSDone: func(i httptrace.DNSDoneInfo) {
-			r.t1 = time.Now()
-			r.DNSLookup = r.t1.Sub(r.t0)
-			r.NameLookup = r.t1.Sub(r.t0)
-		},
-
-		ConnectStart: func(_, _ string) {
-			// When connecting to IP
-			if r.t0.IsZero() {
-				r.t0 = time.Now()
-				r.t1 = r.t0
-			}
-		},
-
-		ConnectDone: func(network, addr string, err error) {
-			r.t2 = time.Now()
-			if r.isTLS {
-				r.TCPConnection = r.t2.Sub(r.t1)
-				r.Connect = r.t2.Sub(r.t0)
-			}
-		},
-
-		GotConn: func(i httptrace.GotConnInfo) {
-			// Handle when keep alive is enabled and connection is reused.
-			// DNSStart(Done) and ConnectStart(Done) is skipped
-			if i.Reused {
-				r.t0 = time.Now()
-				r.t1 = r.t0
-				r.t2 = r.t0
-
-				r.isReused = true
-			}
-		},
-
-		WroteRequest: func(info httptrace.WroteRequestInfo) {
-			r.t3 = time.Now()
-
-			// This means DNSStart, Done and ConnectStart is not
-			// called. This happens if client doesn't use DialContext
-			// or using net package before go1.7.
-			if r.t0.IsZero() && r.t1.IsZero() && r.t2.IsZero() {
-				r.t0 = time.Now()
-				r.t1 = r.t0
-				r.t2 = r.t0
-				r.t3 = r.t0
-			}
-
-			// When connection is reused, TLS handshake is skipped.
-			if r.isReused {
-				r.t3 = r.t0
-			}
-
-			if r.isTLS {
-				r.TLSHandshake = r.t3.Sub(r.t2)
-				r.Pretransfer = r.t3.Sub(r.t0)
-				return
-			}
-
-			r.TCPConnection = r.t3.Sub(r.t1)
-			r.Connect = r.t3.Sub(r.t0)
-
-			r.TLSHandshake = r.t3.Sub(r.t3)
-			r.Pretransfer = r.Connect
-		},
-		GotFirstResponseByte: func() {
-			r.t4 = time.Now()
-			r.ServerProcessing = r.t4.Sub(r.t3)
-			r.StartTransfer = r.t4.Sub(r.t0)
-		},
-	})
+	return withClientTrace(ctx, r)
 }

--- a/httpstat_test.go
+++ b/httpstat_test.go
@@ -190,7 +190,7 @@ func TestHTTPStat_beforeGO17(t *testing.T) {
 	durations := []time.Duration{
 		result.DNSLookup,
 		result.TCPConnection,
-		result.TLSHandshake,
+		// result.TLSHandshake,
 	}
 
 	for i, d := range durations {

--- a/pre_go18.go
+++ b/pre_go18.go
@@ -1,0 +1,114 @@
+// +build !go1.8
+
+package httpstat
+
+import (
+	"context"
+	"net"
+	"net/http/httptrace"
+	"time"
+)
+
+// End sets the time when reading response is done.
+// This must be called after reading response body.
+func (r *Result) End(t time.Time) {
+	r.t5 = t
+
+	// This means result is empty (it does nothing).
+	// Skip setting value(contentTransfer and total will be zero).
+	if r.t0.IsZero() {
+		return
+	}
+
+	r.contentTransfer = r.t5.Sub(r.t4)
+	r.total = r.t5.Sub(r.t0)
+}
+
+func withClientTrace(ctx context.Context, r *Result) context.Context {
+	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			_, port, err := net.SplitHostPort(hostPort)
+			if err != nil {
+				return
+			}
+
+			// Heuristic way to detect
+			if port == "443" {
+				r.isTLS = true
+			}
+		},
+
+		DNSStart: func(i httptrace.DNSStartInfo) {
+			r.t0 = time.Now()
+		},
+		DNSDone: func(i httptrace.DNSDoneInfo) {
+			r.t1 = time.Now()
+			r.DNSLookup = r.t1.Sub(r.t0)
+			r.NameLookup = r.t1.Sub(r.t0)
+		},
+
+		ConnectStart: func(_, _ string) {
+			// When connecting to IP
+			if r.t0.IsZero() {
+				r.t0 = time.Now()
+				r.t1 = r.t0
+			}
+		},
+
+		ConnectDone: func(network, addr string, err error) {
+			r.t2 = time.Now()
+			if r.isTLS {
+				r.TCPConnection = r.t2.Sub(r.t1)
+				r.Connect = r.t2.Sub(r.t0)
+			}
+		},
+
+		GotConn: func(i httptrace.GotConnInfo) {
+			// Handle when keep alive is enabled and connection is reused.
+			// DNSStart(Done) and ConnectStart(Done) is skipped
+			if i.Reused {
+				r.t0 = time.Now()
+				r.t1 = r.t0
+				r.t2 = r.t0
+
+				r.isReused = true
+			}
+		},
+
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			r.t3 = time.Now()
+
+			// This means DNSStart, Done and ConnectStart is not
+			// called. This happens if client doesn't use DialContext
+			// or using net package before go1.7.
+			if r.t0.IsZero() && r.t1.IsZero() && r.t2.IsZero() {
+				r.t0 = time.Now()
+				r.t1 = r.t0
+				r.t2 = r.t0
+				r.t3 = r.t0
+			}
+
+			// When connection is reused, TLS handshake is skipped.
+			if r.isReused {
+				r.t3 = r.t0
+			}
+
+			if r.isTLS {
+				r.TLSHandshake = r.t3.Sub(r.t2)
+				r.Pretransfer = r.t3.Sub(r.t0)
+				return
+			}
+
+			r.TCPConnection = r.t3.Sub(r.t1)
+			r.Connect = r.t3.Sub(r.t0)
+
+			r.TLSHandshake = r.t3.Sub(r.t3)
+			r.Pretransfer = r.Connect
+		},
+		GotFirstResponseByte: func() {
+			r.t4 = time.Now()
+			r.ServerProcessing = r.t4.Sub(r.t3)
+			r.StartTransfer = r.t4.Sub(r.t0)
+		},
+	})
+}


### PR DESCRIPTION
From go1.8, httptrace adds TLSHandshakeStart and Done hook https://tip.golang.org/doc/go1.8#net_http_httptrace Use it for more precise measurement (currently it measures heuristically). 

To support old version, use build tag.