### PR TITLE
Proposed code based on fix to issue #13

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Taichi Nakashima
+Copyright (c) 2017 Jose Tamayo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [travis]: https://travis-ci.org/tcnksm/go-httpstat
 [license]: /LICENSE
 
-`go-httpstat` is a golang package to trace golang HTTP request latency (DNSLookup, TCP Connection and so on). Because it uses [`httptrace`](https://golang.org/pkg/net/http/httptrace/) internally, just creating `go-httpstat` powered `context` and giving it your `http.Request` kicks tracing (no big code modification is required). The original idea came from [`httpstat`](https://github.com/reorx/httpstat) command ( and Dave Cheney's [golang implementation](https://github.com/davecheney/httpstat)) 👏. This package now traces same latency infomation as them.
+`go-httpstat` is a golang package to trace golang HTTP request latency (DNSLookup_duration, TCP Connection and so on). Because it uses [`httptrace`](https://golang.org/pkg/net/http/httptrace/) internally, just creating `go-httpstat` powered `context` and giving it your `http.Request` kicks tracing (no big code modification is required). The original idea came from [`httpstat`](https://github.com/reorx/httpstat) command ( and Dave Cheney's [golang implementation](https://github.com/davecheney/httpstat)) 👏. This package now traces same latency infomation as them.
 
 See usage and example on [GoDoc][godocs]. 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [travis]: https://travis-ci.org/tcnksm/go-httpstat
 [license]: /LICENSE
 
-`go-httpstat` is a golang package to trace golang HTTP request latency (DNSLookup_duration, TCP Connection and so on). Because it uses [`httptrace`](https://golang.org/pkg/net/http/httptrace/) internally, just creating `go-httpstat` powered `context` and giving it your `http.Request` kicks tracing (no big code modification is required). The original idea came from [`httpstat`](https://github.com/reorx/httpstat) command ( and Dave Cheney's [golang implementation](https://github.com/davecheney/httpstat)) 👏. This package now traces same latency infomation as them.
+`go-httpstat` is a golang package to trace golang HTTP request latency (DNSLookup, TCP Connection and so on). Because it uses [`httptrace`](https://golang.org/pkg/net/http/httptrace/) internally, just creating `go-httpstat` powered `context` and giving it your `http.Request` kicks tracing (no big code modification is required). The original idea came from [`httpstat`](https://github.com/reorx/httpstat) command ( and Dave Cheney's [golang implementation](https://github.com/davecheney/httpstat)) 👏. This package now traces same latency infomation as them.
 
 See usage and example on [GoDoc][godocs]. 
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Use `go get`,
 $ go get github.com/tcnksm/go-httpstat
 ```
 
-## Author
+## Authors
 
-[Taichi Nakashima](https://github.com/tcnksm)
+Original author [Taichi Nakashima](https://github.com/tcnksm)
+
+Collaboration on this fork by [Benoit Remy](bremy@cns-com.com) and [Jose Tamayo](jtamayo@cns-com.com)

--- a/go18.go
+++ b/go18.go
@@ -13,37 +13,32 @@ import (
 // This must be called after reading response body.
 func (r *Result) End(t time.Time) {
 	r.trasferDone = t
-	//r.t5 = t // for Formatter
-
-	// This means result is empty (it does nothing).
-	// Skip setting value(contentTransfer and total will be zero).
+	
+	// This means there was no initial HTTP Request.
+	// Skip setting value(ContentTransfer and Total will be zero).
 	if r.dnsStart.IsZero() {
 		return
 	}
 
 	r.ContentTransfer = r.trasferDone.Sub(r.transferStart)
-
 	r.Total = r.trasferDone.Sub(r.dnsStart)
 }
 
 func withClientTrace(ctx context.Context, r *Result) context.Context {
 	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		
 		DNSStart: func(i httptrace.DNSStartInfo) {
 			r.dnsStart = time.Now()
 		},
 
 		DNSDone: func(i httptrace.DNSDoneInfo) {
 			r.dnsDone = time.Now()
-
 			r.DNSLookup = r.dnsDone.Sub(r.dnsStart)
-			r.Total = r.DNSLookup
 			r.NameLookup = r.DNSLookup
-
 		},
 
 		ConnectStart: func(_, _ string) {
 			r.tcpStart = time.Now()
-
 			// When connecting to IP (When no DNS lookup)
 			if r.dnsStart.IsZero() {
 				r.dnsStart = r.tcpStart
@@ -53,7 +48,6 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 
 		ConnectDone: func(network, addr string, err error) {
 			r.tcpDone = time.Now()
-
 			r.TCPConnection = r.tcpDone.Sub(r.tcpStart)
 			r.Connect = r.tcpDone.Sub(r.dnsStart)
 
@@ -66,14 +60,12 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 
 		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
 			r.tlsDone = time.Now()
-
 			r.TLSHandshake = r.tlsDone.Sub(r.tlsStart)
-
 			r.Pretransfer = r.tlsDone.Sub(r.dnsStart)
 		},
 
 		GotConn: func(i httptrace.GotConnInfo) {
-			// Handle when keep alive is used and connection is reused.
+			// Handle when keepalive is used and connection is reused.
 			// DNSStart(Done) and ConnectStart(Done) is skipped
 			if i.Reused {
 				r.isReused = true
@@ -82,6 +74,10 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 				r.dnsDone = now
 				r.tcpStart = now
 				r.tcpDone = now
+				if r.isTLS {
+					r.tlsStart = now
+					r.tlsDone = now
+				}
 			}
 		},
 
@@ -92,15 +88,14 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 			// When connection is re-used, DNS/TCP/TLS hook is not called.
 			if (r.dnsStart.IsZero() && r.tcpStart.IsZero()) || (r.isReused) {
 				now := r.serverStart
-
 				r.dnsStart = now
 				r.dnsDone = now
 				r.tcpStart = now
 				r.tcpDone = now
-				if r.isTLS {
-					r.tlsStart = now
-					r.tlsDone = now
-				}
+				//if r.isTLS {
+				//	r.tlsStart = now
+				//	r.tlsDone = now
+				//}
 			}
 
 		},
@@ -109,7 +104,6 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 			r.serverDone = time.Now()
 			r.ServerProcessing = r.serverDone.Sub(r.serverStart)
 			r.StartTransfer = r.serverDone.Sub(r.dnsStart)
-
 			r.transferStart = r.serverDone
 		},
 	})

--- a/go18.go
+++ b/go18.go
@@ -21,9 +21,9 @@ func (r *Result) End(t time.Time) {
 		return
 	}
 
-	r.ContentTransfer_duration = r.trasferDone.Sub(r.transferStart)
-	r.Total_duration += r.ContentTransfer_duration
-	r.End_done = r.trasferDone.Sub(r.dnsStart)
+	r.ContentTransfer = r.trasferDone.Sub(r.transferStart)
+
+	r.Total = r.trasferDone.Sub(r.dnsStart)
 }
 
 func withClientTrace(ctx context.Context, r *Result) context.Context {
@@ -34,11 +34,11 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 
 		DNSDone: func(i httptrace.DNSDoneInfo) {
 			r.dnsDone = time.Now()
-			
-			r.DNSLookup_duration = r.dnsDone.Sub(r.dnsStart)
-			r.Total_duration = r.DNSLookup_duration
-			r.NameLookup_done = r.DNSLookup_duration
-			
+
+			r.DNSLookup = r.dnsDone.Sub(r.dnsStart)
+			r.Total = r.DNSLookup
+			r.NameLookup = r.DNSLookup
+
 		},
 
 		ConnectStart: func(_, _ string) {
@@ -54,9 +54,9 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 		ConnectDone: func(network, addr string, err error) {
 			r.tcpDone = time.Now()
 
-			r.TCPConnection_duration = r.tcpDone.Sub(r.tcpStart)
-			r.Connect_done = r.tcpDone.Sub(r.dnsStart)
-			r.Total_duration += r.TCPConnection_duration
+			r.TCPConnection = r.tcpDone.Sub(r.tcpStart)
+			r.Connect = r.tcpDone.Sub(r.dnsStart)
+
 		},
 
 		TLSHandshakeStart: func() {
@@ -67,9 +67,9 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
 			r.tlsDone = time.Now()
 
-			r.TLSHandshake_duration = r.tlsDone.Sub(r.tlsStart)
-			r.Total_duration +=r.TLSHandshake_duration
-			r.Pretransfer_done = r.tlsDone.Sub(r.dnsStart)
+			r.TLSHandshake = r.tlsDone.Sub(r.tlsStart)
+
+			r.Pretransfer = r.tlsDone.Sub(r.dnsStart)
 		},
 
 		GotConn: func(i httptrace.GotConnInfo) {
@@ -107,9 +107,9 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 
 		GotFirstResponseByte: func() {
 			r.serverDone = time.Now()
-			r.ServerProcessing_duration = r.serverDone.Sub(r.serverStart)
-			r.StartTransfer_done = r.serverDone.Sub(r.dnsStart)
-			r.Total_duration += r.ServerProcessing_duration
+			r.ServerProcessing = r.serverDone.Sub(r.serverStart)
+			r.StartTransfer = r.serverDone.Sub(r.dnsStart)
+
 			r.transferStart = r.serverDone
 		},
 	})

--- a/httpstat.go
+++ b/httpstat.go
@@ -20,13 +20,14 @@ type Result struct {
 	ServerProcessing time.Duration
 	ContentTransfer  time.Duration
 
-	// The followings are timeline of request
+	// The followings are timeline of request, starting from the first DNS query
 	NameLookup    time.Duration
 	Connect       time.Duration
 	Pretransfer   time.Duration
 	StartTransfer time.Duration
 	Total            time.Duration
 
+	// These are proper timestamps of the different events
 	dnsStart      time.Time
 	dnsDone       time.Time
 	tcpStart      time.Time
@@ -36,7 +37,7 @@ type Result struct {
 	serverStart   time.Time
 	serverDone    time.Time
 	transferStart time.Time
-	trasferDone   time.Time // need to be provided from outside
+	trasferDone   time.Time // need to be provided from outside in the End() method
 
 	// isTLS is true when connection seems to use TLS
 	isTLS bool
@@ -64,20 +65,6 @@ func (r *Result) timeline() map[string]time.Duration {
 		
 	}
 }
-
-// ContentTransfer returns the duration of content transfer time.
-// It is from first response byte to the given time. The time must
-// be time after read body (go-httpstat can not detect that time).
-//func (r *Result) ContentTransfer(t time.Time) time.Duration {
-	//return t.Sub(r.t4)
-//}
-
-// Total returns the duration of total http request.
-// It is from dns lookup start time to the given time. The
-// time must be time after read body (go-httpstat can not detect that time).
-//func (r *Result) Total(t time.Time) time.Duration {
-	//return t.Sub(r.t0)
-//}
 
 // Format formats stats result.
 func (r Result) Format(s fmt.State, verb rune) {

--- a/httpstat.go
+++ b/httpstat.go
@@ -1,4 +1,4 @@
-// Package httpstat traces HTTP latency infomation (DNSLookup_duration, TCP Connection and so on) on any golang HTTP request.
+// Package httpstat traces HTTP latency infomation (DNSLookup, TCP Connection and so on) on any golang HTTP request.
 // It uses `httptrace` package. Just create `go-httpstat` powered `context.Context` and give it your `http.Request` (no big code modification is required).
 package httpstat
 
@@ -14,26 +14,18 @@ import (
 // Result stores httpstat info.
 type Result struct {
 	// The following are duration for each phase
-	DNSLookup_duration        time.Duration
-	TCPConnection_duration    time.Duration
-	TLSHandshake_duration     time.Duration
-	ServerProcessing_duration time.Duration
-	ContentTransfer_duration  time.Duration
-	Total_duration            time.Duration
+	DNSLookup        time.Duration
+	TCPConnection    time.Duration
+	TLSHandshake     time.Duration
+	ServerProcessing time.Duration
+	ContentTransfer  time.Duration
 
 	// The followings are timeline of request
-	NameLookup_done    time.Duration
-	Connect_done       time.Duration
-	Pretransfer_done   time.Duration
-	StartTransfer_done time.Duration
-	End_done           time.Duration
-
-	//t0 time.Time
-	//t1 time.Time
-	//t2 time.Time
-	//t3 time.Time
-	//t4 time.Time
-	//t5 time.Time // need to be provided from outside
+	NameLookup    time.Duration
+	Connect       time.Duration
+	Pretransfer   time.Duration
+	StartTransfer time.Duration
+	Total            time.Duration
 
 	dnsStart      time.Time
 	dnsDone       time.Time
@@ -55,21 +47,21 @@ type Result struct {
 
 func (r *Result) durations() map[string]time.Duration {
 	return map[string]time.Duration{
-		"DNSLookup_duration":        r.DNSLookup_duration,
-		"TCPConnection":    r.TCPConnection_duration,
-		"TLSHandshake":     r.TLSHandshake_duration,
-		"ServerProcessing": r.ServerProcessing_duration,
-		"ContentTransfer":  r.ContentTransfer_duration,
-		"Total":            r.Total_duration,
+		"DNSLookup":        r.DNSLookup,
+		"TCPConnection":    r.TCPConnection,
+		"TLSHandshake":     r.TLSHandshake,
+		"ServerProcessing": r.ServerProcessing,
+		"ContentTransfer":  r.ContentTransfer,
+		"Total":            r.Total,
 	}
 }
 func (r *Result) timeline() map[string]time.Duration {
 	return map[string]time.Duration{
-		"NameLookup":    r.NameLookup_done,
-		"Connect":       r.Connect_done,
-		"Pretransfer":   r.Pretransfer_done,
-		"StartTransfer": r.StartTransfer_done,
-		"End":         r.End_done,
+		"NameLookup":    r.NameLookup,
+		"Connect":       r.Connect,
+		"Pretransfer":   r.Pretransfer,
+		"StartTransfer": r.StartTransfer,
+		
 	}
 }
 
@@ -94,33 +86,33 @@ func (r Result) Format(s fmt.State, verb rune) {
 		if s.Flag('+') {
 			var buf bytes.Buffer
 			fmt.Fprintf(&buf, "DNS lookup:        %4d ms\n",
-				int(r.DNSLookup_duration/time.Millisecond))
+				int(r.DNSLookup/time.Millisecond))
 			fmt.Fprintf(&buf, "TCP connection:    %4d ms\n",
-				int(r.TCPConnection_duration/time.Millisecond))
+				int(r.TCPConnection/time.Millisecond))
 			fmt.Fprintf(&buf, "TLS handshake:     %4d ms\n",
-				int(r.TLSHandshake_duration/time.Millisecond))
+				int(r.TLSHandshake/time.Millisecond))
 			fmt.Fprintf(&buf, "Server processing: %4d ms\n",
-				int(r.ServerProcessing_duration/time.Millisecond))
+				int(r.ServerProcessing/time.Millisecond))
 
 			if !r.trasferDone.IsZero() {
 				fmt.Fprintf(&buf, "Content transfer:  %4d ms\n\n",
-					int(r.ContentTransfer_duration/time.Millisecond))
+					int(r.ContentTransfer/time.Millisecond))
 			} else {
 				fmt.Fprintf(&buf, "Content transfer:  %4s ms\n\n", "-")
 			}
 
 			fmt.Fprintf(&buf, "Name Lookup:    %4d ms\n",
-				int(r.NameLookup_done/time.Millisecond))
+				int(r.NameLookup/time.Millisecond))
 			fmt.Fprintf(&buf, "Connect:        %4d ms\n",
-				int(r.Connect_done/time.Millisecond))
+				int(r.Connect/time.Millisecond))
 			fmt.Fprintf(&buf, "Pre Transfer:   %4d ms\n",
-				int(r.Pretransfer_done/time.Millisecond))
+				int(r.Pretransfer/time.Millisecond))
 			fmt.Fprintf(&buf, "Start Transfer: %4d ms\n",
-				int(r.StartTransfer_done/time.Millisecond))
+				int(r.StartTransfer/time.Millisecond))
 
 			if !r.trasferDone.IsZero() {
 				fmt.Fprintf(&buf, "Total:          %4d ms\n",
-					int(r.Total_duration/time.Millisecond))
+					int(r.Total/time.Millisecond))
 			} else {
 				fmt.Fprintf(&buf, "Total:          %4s ms\n", "-")
 			}

--- a/httpstat_test.go
+++ b/httpstat_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 const (
-	TestDomainHTTP  = "http://example.com"
-	TestDomainHTTPS = "https://example.com"
+	TestDomainHTTP  = "http://http://www.web-stat.com/"
+	TestDomainHTTPS = "https://blog.golang.org/"
 )
 
+// Recommended way to instantiate a Transport
+// Should cache connections
 func DefaultTransport() *http.Transport {
 	// It comes from std transport.go
 	return &http.Transport{
@@ -26,17 +28,53 @@ func DefaultTransport() *http.Transport {
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
+		TLSHandshake_durationTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 }
 
-// To avoid shared transport
+// Just forgot about the Dialer
+func NoDialerTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		MaxIdleConns:          1,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshake_durationTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// Before go1.7, it uses non context based Dial function.
+// It doesn't support httptrace.
+func OldTransport() *http.Transport {
+	return &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 5 * time.Second,
+		}).Dial,
+		TLSHandshake_durationTimeout: 5 * time.Second,
+	}
+}
+
 func DefaultClient() *http.Client {
 	return &http.Client{
 		Transport: DefaultTransport(),
 	}
 }
+
+func NoDialerClient() *http.Client {
+	return &http.Client{
+		Transport: NoDialerTransport(),
+	}
+}
+
+func OldDialerClient() *http.Client {
+	return &http.Client{
+		Transport: OldTransport(),
+		Timeout:   time.Second * 10,
+	}
+}
+
+
 
 func NewRequest(t *testing.T, urlStr string, result *Result) *http.Request {
 	req, err := http.NewRequest("GET", urlStr, nil)
@@ -73,6 +111,8 @@ func TestHTTPStat_HTTPS(t *testing.T) {
 			t.Fatalf("expect %s to be non-zero", k)
 		}
 	}
+	
+	
 }
 
 func TestHTTPStat_HTTP(t *testing.T) {
@@ -95,13 +135,13 @@ func TestHTTPStat_HTTP(t *testing.T) {
 		t.Fatal("isTLS should be false")
 	}
 
-	if got, want := result.TLSHandshake, 0*time.Millisecond; got != want {
-		t.Fatalf("TLSHandshake time of HTTP = %d, want %d", got, want)
+	if got, want := result.TLSHandshake_duration, 0*time.Millisecond; got != want {
+		t.Fatalf("TLSHandshake_duration time of HTTP = %d, want %d", got, want)
 	}
 
 	// Except TLS should be non zero
 	durations := result.durations()
-	delete(durations, "TLSHandshake")
+	delete(durations, "TLSHandshake_duration")
 
 	for k, d := range durations {
 		if d <= 0*time.Millisecond {
@@ -110,7 +150,7 @@ func TestHTTPStat_HTTP(t *testing.T) {
 	}
 }
 
-func TestHTTPStat_KeepAlive(t *testing.T) {
+func TestHTTPStat_KeepAlive_HTTPS(t *testing.T) {
 	req1, err := http.NewRequest("GET", TestDomainHTTPS, nil)
 	if err != nil {
 		t.Fatal("NewRequest failed:", err)
@@ -145,9 +185,9 @@ func TestHTTPStat_KeepAlive(t *testing.T) {
 	// The following values should be zero.
 	// Because connection is reused.
 	durations := []time.Duration{
-		result.DNSLookup,
-		result.TCPConnection,
-		result.TLSHandshake,
+		result.DNSLookup_duration,
+		result.TCPConnect_doneion_duration,
+		result.TLSHandshake_duration,
 	}
 
 	for i, d := range durations {
@@ -157,23 +197,61 @@ func TestHTTPStat_KeepAlive(t *testing.T) {
 	}
 }
 
+func TestHTTPStat_KeepAlive_HTTP(t *testing.T) {
+	req1, err := http.NewRequest("GET", TestDomainHTTP, nil)
+	if err != nil {
+		t.Fatal("NewRequest failed:", err)
+	}
+
+	client := DefaultClient()
+	res1, err := client.Do(req1)
+	if err != nil {
+		t.Fatal("Request failed:", err)
+	}
+
+	if _, err := io.Copy(ioutil.Discard, res1.Body); err != nil {
+		t.Fatal("Copy body failed:", err)
+	}
+	res1.Body.Close()
+
+	var result Result
+	req2 := NewRequest(t, TestDomainHTTP, &result)
+
+	// When second request, connection should be re-used.
+	res2, err := client.Do(req2)
+	if err != nil {
+		t.Fatal("Request failed:", err)
+	}
+
+	if _, err := io.Copy(ioutil.Discard, res2.Body); err != nil {
+		t.Fatal("Copy body failed:", err)
+	}
+	res2.Body.Close()
+	result.End(time.Now())
+
+	// The following values should be zero.
+	// Because connection is reused.
+	durations := []time.Duration{
+		result.DNSLookup_duration,
+		result.TCPConnect_doneion_duration,
+	}
+
+	for i, d := range durations {
+		if got, want := d, 0*time.Millisecond; got != want {
+			t.Fatalf("#%d expect %d to be eq %d", i, got, want)
+		}
+	}
+}
+
+
 func TestHTTPStat_beforeGO17(t *testing.T) {
 	var result Result
-	req := NewRequest(t, TestDomainHTTPS, &result)
-
+	
 	// Before go1.7, it uses non context based Dial function.
 	// It doesn't support httptrace.
-	oldTransport := &http.Transport{
-		Dial: (&net.Dialer{
-			Timeout: 5 * time.Second,
-		}).Dial,
-		TLSHandshakeTimeout: 5 * time.Second,
-	}
+	client := OldDialerClient()
 
-	client := &http.Client{
-		Timeout:   time.Second * 10,
-		Transport: oldTransport,
-	}
+	req1 := NewRequest(t, TestDomainHTTPS, &result)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -186,11 +264,156 @@ func TestHTTPStat_beforeGO17(t *testing.T) {
 	res.Body.Close()
 	result.End(time.Now())
 
-	// The following values are not mesured.
+	// The following values are not mesured, should be 0
 	durations := []time.Duration{
-		result.DNSLookup,
-		result.TCPConnection,
-		// result.TLSHandshake,
+		result.DNSLookup_duration,
+		result.TCPConnect_doneion_duration,
+		result.TLSHandshake_duration,
+	}
+
+	for i, d := range durations {
+		if got, want := d, 0*time.Millisecond; got != want {
+			t.Fatalf("#%d expect %d to be eq %d", i, got, want)
+		}
+	}
+	
+	req2 := NewRequest(t, TestDomainHTTP, &result)
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal("client.Do failed:", err)
+	}
+
+	if _, err := io.Copy(ioutil.Discard, res.Body); err != nil {
+		t.Fatal("io.Copy failed:", err)
+	}
+	res.Body.Close()
+	result.End(time.Now())
+
+	// The following values are not mesured, should be 0
+	durations := []time.Duration{
+		result.DNSLookup_duration,
+		result.TCPConnect_doneion_duration,
+		result.TLSHandshake_duration,
+	}
+
+	for i, d := range durations {
+		if got, want := d, 0*time.Millisecond; got != want {
+			t.Fatalf("#%d expect %d to be eq %d", i, got, want)
+		}
+	}
+}
+
+
+func TestHTTPStat_BadDialer_HTTPS(t *testing.T) {
+	var result Result
+	
+	// Using the Transport but without a Dialer
+	client := NoDialerClient()
+
+	req1 := NewRequest(t, TestDomainHTTPS, &result)
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal("client.Do failed:", err)
+	}
+
+	if _, err := io.Copy(ioutil.Discard, res.Body); err != nil {
+		t.Fatal("io.Copy failed:", err)
+	}
+	res.Body.Close()
+	result.End(time.Now())
+
+	if !result.isTLS {
+		t.Fatal("isTLS should be true")
+	}
+
+	for k, d := range result.durations() {
+		if d <= 0*time.Millisecond {
+			t.Fatalf("expect %s to be non-zero", k)
+		}
+	}
+
+	
+	req2 := NewRequest(t, TestDomainHTTPS, &result)
+
+	// When second request, connection should be re-used.
+	res2, err := client.Do(req2)
+	if err != nil {
+		t.Fatal("Request failed:", err)
+	}
+
+	if _, err := io.Copy(ioutil.Discard, res2.Body); err != nil {
+		t.Fatal("Copy body failed:", err)
+	}
+	res2.Body.Close()
+	result.End(time.Now())
+
+	// The following values should be zero.
+	// Because connection is reused.
+	durations := []time.Duration{
+		result.DNSLookup_duration,
+		result.TCPConnect_doneion_duration,
+		result.TLSHandshake_duration,
+	}
+
+	for i, d := range durations {
+		if got, want := d, 0*time.Millisecond; got != want {
+			t.Fatalf("#%d expect %d to be eq %d", i, got, want)
+		}
+	}
+}
+
+func TestHTTPStat_BadDialer_HTTP(t *testing.T) {
+	var result Result
+	
+	// Using the Transport but without a Dialer
+	client := NoDialerClient()
+
+	req1 := NewRequest(t, TestDomainHTTP, &result)
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal("client.Do failed:", err)
+	}
+
+	if _, err := io.Copy(ioutil.Discard, res.Body); err != nil {
+		t.Fatal("io.Copy failed:", err)
+	}
+	res.Body.Close()
+	result.End(time.Now())
+
+	if !result.isTLS {
+		t.Fatal("isTLS should be true")
+	}
+
+	for k, d := range result.durations() {
+		if d <= 0*time.Millisecond {
+			t.Fatalf("expect %s to be non-zero", k)
+		}
+	}
+
+	
+	req2 := NewRequest(t, TestDomainHTTP, &result)
+
+	// When second request, connection should be re-used.
+	res2, err := client.Do(req2)
+	if err != nil {
+		t.Fatal("Request failed:", err)
+	}
+
+	if _, err := io.Copy(ioutil.Discard, res2.Body); err != nil {
+		t.Fatal("Copy body failed:", err)
+	}
+	res2.Body.Close()
+	result.End(time.Now())
+
+	// The following values should be zero.
+	// Because connection is reused.
+	durations := []time.Duration{
+		result.DNSLookup_duration,
+		result.TCPConnect_doneion_duration,
+		result.TLSHandshake_duration,
 	}
 
 	for i, d := range durations {
@@ -205,30 +428,29 @@ func TestTotal_Zero(t *testing.T) {
 	result.End(time.Now())
 
 	zero := 0 * time.Millisecond
-	if result.total != zero {
-		t.Fatalf("Total time is %d, want %d", result.total, zero)
+	if result.Total_duration != zero {
+		t.Fatalf("Total time is %d, want %d", result.Total_duration, zero)
 	}
 
-	if result.contentTransfer != zero {
-		t.Fatalf("Total time is %d, want %d", result.contentTransfer, zero)
+	if result.ContentTransfer_duration != zero {
+		t.Fatalf("Total time is %d, want %d", result.ContentTransfer_duration, zero)
 	}
 }
 
 func TestHTTPStat_Formatter(t *testing.T) {
 	result := Result{
-		DNSLookup:        100 * time.Millisecond,
-		TCPConnection:    100 * time.Millisecond,
-		TLSHandshake:     100 * time.Millisecond,
-		ServerProcessing: 100 * time.Millisecond,
-		contentTransfer:  100 * time.Millisecond,
+		DNSLookup_duration:        100 * time.Millisecond,
+		TCPConnect_doneion_duration:    100 * time.Millisecond,
+		TLSHandshake_duration:     100 * time.Millisecond,
+		ServerProcessing_duration: 100 * time.Millisecond,
+		ContentTransfer_duration:  100 * time.Millisecond,
+		NameLookup_done:    100 * time.Millisecond,
+		Connect_done:       100 * time.Millisecond,
+		Pretransfer_done:   100 * time.Millisecond,
+		StartTransfer_done: 100 * time.Millisecond,
+		End_done:         100 * time.Millisecond,
 
-		NameLookup:    100 * time.Millisecond,
-		Connect:       100 * time.Millisecond,
-		Pretransfer:   100 * time.Millisecond,
-		StartTransfer: 100 * time.Millisecond,
-		total:         100 * time.Millisecond,
-
-		t5: time.Now(),
+		trasferDone: time.Now(),
 	}
 
 	want := `DNS lookup:         100 ms
@@ -238,7 +460,7 @@ Server processing:  100 ms
 Content transfer:   100 ms
 
 Name Lookup:     100 ms
-Connect:         100 ms
+Connect_done:         100 ms
 Pre Transfer:    100 ms
 Start Transfer:  100 ms
 Total:           100 ms

--- a/httpstat_test.go
+++ b/httpstat_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	TestDomainHTTP  = "http://www.web-stat.com/"
-	TestDomainHTTPS = "https://blog.golang.org/"
+	TestDomainHTTP  = "http://example.com/"
+	TestDomainHTTPS = "https://example.com/"
+	//TestDomainHTTP  = "http://www.web-stat.com/"
+	//TestDomainHTTPS = "https://blog.golang.org/"
 )
 
 // Recommended way to instantiate a Transport

--- a/pre_go18.go
+++ b/pre_go18.go
@@ -91,7 +91,7 @@ func withClientTrace(ctx context.Context, r *Result) context.Context {
 			if r.isTLS {
 				r.TLSHandshake = r.serverStart.Sub(r.tcpDone)
 				r.Total +=r.TLSHandshake
-				r.Pretransfer_done = r.serverStart.Sub(r.dnsStart)
+				r.Pretransfer = r.serverStart.Sub(r.dnsStart)
 			}
 
 		},


### PR DESCRIPTION
Proposing some changes in the library, to correct some behaviour seen in Go1.8

When we started using the library with Go1.8, the contentTransfer() and Total() methods returned out of order values. So we propose to simplify the internals of the struct Result, depend only on the End() method.

Also some test were added to test for Client that has a very simple Transport, no Dialer nor DialerContext, and running in go 1.8. This was our case and it was better to have it tested here.

The tests are passing:

go test -v -parallel=4 github.com/tcnksm/go-httpstat
=== RUN   TestHTTPStat_HTTPS
	DNSDone
	tcpDone
	tlsDone
	GotConn
	serverStart
--- PASS: TestHTTPStat_HTTPS (0.71s)
=== RUN   TestHTTPStat_HTTP
	DNSDone
	tcpDone
	GotConn
	serverStart
--- PASS: TestHTTPStat_HTTP (0.02s)
=== RUN   TestHTTPStat_KeepAlive_HTTPS
	GotConn  >>>> Only cached connection prints
	serverStart  >>>> Only cached connection prints
--- PASS: TestHTTPStat_KeepAlive_HTTPS (1.17s)
=== RUN   TestHTTPStat_KeepAlive_HTTP
	GotConn  >>>> Only cached connection prints
	serverStart >>>> Only cached connection prints
--- PASS: TestHTTPStat_KeepAlive_HTTP (0.02s)
=== RUN   TestHTTPStat_beforeGO17
	tlsDone    >>>> No DNS nor TCP stages
	GotConn
	serverStart
	GotConn    >>>> Cached connetion
	serverStart
--- PASS: TestHTTPStat_beforeGO17 (0.40s)
=== RUN   TestHTTPStat_NoDialer_HTTPS
	DNSDone
	tcpDone
	tlsDone
	GotConn
	serverStart
	GotConn    >>>> Cached connetion
	serverStart    >>>> Cached connetion
--- PASS: TestHTTPStat_NoDialer_HTTPS (1.25s)
=== RUN   TestHTTPStat_NoDialer_HTTP
	DNSDone
	tcpDone
	GotConn
	serverStart
	GotConn    >>>> Cached connetion
	serverStart    >>>> Cached connetion
--- PASS: TestHTTPStat_NoDialer_HTTP (0.02s)
=== RUN   TestTotal_Zero
--- PASS: TestTotal_Zero (0.00s)
=== RUN   TestHTTPStat_Formatter
--- PASS: TestHTTPStat_Formatter (0.00s)
PASS
ok  	github.com/tcnksm/go-httpstat	3.593s
