### PR TITLE
Reduce cpu, memory, and allocations in formatter

### DIFF
--- a/httpstat.go
+++ b/httpstat.go
@@ -3,7 +3,6 @@
 package httpstat
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -87,39 +86,37 @@ func (r Result) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			var buf bytes.Buffer
-			fmt.Fprintf(&buf, "DNS lookup:        %4d ms\n",
+			fmt.Fprintf(s, "DNS lookup:        %4d ms\n",
 				int(r.DNSLookup/time.Millisecond))
-			fmt.Fprintf(&buf, "TCP connection:    %4d ms\n",
+			fmt.Fprintf(s, "TCP connection:    %4d ms\n",
 				int(r.TCPConnection/time.Millisecond))
-			fmt.Fprintf(&buf, "TLS handshake:     %4d ms\n",
+			fmt.Fprintf(s, "TLS handshake:     %4d ms\n",
 				int(r.TLSHandshake/time.Millisecond))
-			fmt.Fprintf(&buf, "Server processing: %4d ms\n",
+			fmt.Fprintf(s, "Server processing: %4d ms\n",
 				int(r.ServerProcessing/time.Millisecond))
 
 			if !r.t5.IsZero() {
-				fmt.Fprintf(&buf, "Content transfer:  %4d ms\n\n",
+				fmt.Fprintf(s, "Content transfer:  %4d ms\n\n",
 					int(r.contentTransfer/time.Millisecond))
 			} else {
-				fmt.Fprintf(&buf, "Content transfer:  %4s ms\n\n", "-")
+				fmt.Fprintf(s, "Content transfer:  %4s ms\n\n", "-")
 			}
 
-			fmt.Fprintf(&buf, "Name Lookup:    %4d ms\n",
+			fmt.Fprintf(s, "Name Lookup:    %4d ms\n",
 				int(r.NameLookup/time.Millisecond))
-			fmt.Fprintf(&buf, "Connect:        %4d ms\n",
+			fmt.Fprintf(s, "Connect:        %4d ms\n",
 				int(r.Connect/time.Millisecond))
-			fmt.Fprintf(&buf, "Pre Transfer:   %4d ms\n",
+			fmt.Fprintf(s, "Pre Transfer:   %4d ms\n",
 				int(r.Pretransfer/time.Millisecond))
-			fmt.Fprintf(&buf, "Start Transfer: %4d ms\n",
+			fmt.Fprintf(s, "Start Transfer: %4d ms\n",
 				int(r.StartTransfer/time.Millisecond))
 
 			if !r.t5.IsZero() {
-				fmt.Fprintf(&buf, "Total:          %4d ms\n",
+				fmt.Fprintf(s, "Total:          %4d ms\n",
 					int(r.total/time.Millisecond))
 			} else {
-				fmt.Fprintf(&buf, "Total:          %4s ms\n", "-")
+				fmt.Fprintf(s, "Total:          %4s ms\n", "-")
 			}
-			io.WriteString(s, buf.String())
 			return
 		}
 

--- a/httpstat_test.go
+++ b/httpstat_test.go
@@ -214,24 +214,25 @@ func TestTotal_Zero(t *testing.T) {
 	}
 }
 
+var testResult = Result{
+	DNSLookup:        100 * time.Millisecond,
+	TCPConnection:    100 * time.Millisecond,
+	TLSHandshake:     100 * time.Millisecond,
+	ServerProcessing: 100 * time.Millisecond,
+	contentTransfer:  100 * time.Millisecond,
+
+	NameLookup:    100 * time.Millisecond,
+	Connect:       100 * time.Millisecond,
+	Pretransfer:   100 * time.Millisecond,
+	StartTransfer: 100 * time.Millisecond,
+	total:         100 * time.Millisecond,
+
+	t5: time.Now(),
+}
+
 func TestHTTPStat_Formatter(t *testing.T) {
-	result := Result{
-		DNSLookup:        100 * time.Millisecond,
-		TCPConnection:    100 * time.Millisecond,
-		TLSHandshake:     100 * time.Millisecond,
-		ServerProcessing: 100 * time.Millisecond,
-		contentTransfer:  100 * time.Millisecond,
 
-		NameLookup:    100 * time.Millisecond,
-		Connect:       100 * time.Millisecond,
-		Pretransfer:   100 * time.Millisecond,
-		StartTransfer: 100 * time.Millisecond,
-		total:         100 * time.Millisecond,
-
-		t5: time.Now(),
-	}
-
-	want := `DNS lookup:         100 ms
+	const want = `DNS lookup:         100 ms
 TCP connection:     100 ms
 TLS handshake:      100 ms
 Server processing:  100 ms
@@ -244,8 +245,22 @@ Start Transfer:  100 ms
 Total:           100 ms
 `
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%+v", result)
+	fmt.Fprintf(&buf, "%+v", testResult)
 	if got := buf.String(); want != got {
 		t.Fatalf("expect to be eq:\n\nwant:\n\n%s\ngot:\n\n%s\n", want, got)
+	}
+}
+
+func BenchmarkHTTPStat_Formatter(b *testing.B) {
+	for _, formatter := range []string{"%+v", "%v"} {
+		b.Run(formatter, func(b *testing.B) {
+			var buf bytes.Buffer
+
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				fmt.Fprintf(&buf, formatter, testResult)
+				buf.Reset()
+			}
+		})
 	}
 }


### PR DESCRIPTION
adds a benchmark for both `%v` and `%+v`.
reduces cpu, memory, and allocations in the formatting code itself.
- `%+v` write directly to `fmt.State` as it is itself an `io.Writer`
- `%v` reduce memory by avoiding `[]string` and `strings.Join` with a `bytes.Buffer`

`benchcmp` output:
```
benchmark                             old ns/op     new ns/op     delta
BenchmarkHTTPStat_Formatter/%+v-8     2652          2053          -22.59%
BenchmarkHTTPStat_Formatter/%v-8      4347          2786          -35.91%

benchmark                             old allocs     new allocs     delta
BenchmarkHTTPStat_Formatter/%+v-8     16             11             -31.25%
BenchmarkHTTPStat_Formatter/%v-8      37             16             -56.76%

benchmark                             old bytes     new bytes     delta
BenchmarkHTTPStat_Formatter/%+v-8     1697          560           -67.00%
BenchmarkHTTPStat_Formatter/%v-8      2309          1532          -33.65%
```