### PR TITLE
Make `ContentTransfer ()`, `End ()` and `Format()` work even after go1.8

### DIFF
--- a/go18.go
+++ b/go18.go
@@ -13,7 +13,6 @@ import (
 // This must be called after reading response body.
 func (r *Result) End(t time.Time) {
 	r.trasferDone = t
-	r.t5 = t // for Formatter
 
 	// This means result is empty (it does nothing).
 	// Skip setting value(contentTransfer and total will be zero).

--- a/go18.go
+++ b/go18.go
@@ -25,6 +25,20 @@ func (r *Result) End(t time.Time) {
 	r.total = r.trasferDone.Sub(r.dnsStart)
 }
 
+// ContentTransfer returns the duration of content transfer time.
+// It is from first response byte to the given time. The time must
+// be time after read body (go-httpstat can not detect that time).
+func (r *Result) ContentTransfer(t time.Time) time.Duration {
+	return t.Sub(r.serverDone)
+}
+
+// Total returns the duration of total http request.
+// It is from dns lookup start time to the given time. The
+// time must be time after read body (go-httpstat can not detect that time).
+func (r *Result) Total(t time.Time) time.Duration {
+	return t.Sub(r.dnsStart)
+}
+
 func withClientTrace(ctx context.Context, r *Result) context.Context {
 	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
 		DNSStart: func(i httptrace.DNSStartInfo) {

--- a/httpstat.go
+++ b/httpstat.go
@@ -68,20 +68,6 @@ func (r *Result) durations() map[string]time.Duration {
 	}
 }
 
-// ContentTransfer returns the duration of content transfer time.
-// It is from first response byte to the given time. The time must
-// be time after read body (go-httpstat can not detect that time).
-func (r *Result) ContentTransfer(t time.Time) time.Duration {
-	return t.Sub(r.t4)
-}
-
-// Total returns the duration of total http request.
-// It is from dns lookup start time to the given time. The
-// time must be time after read body (go-httpstat can not detect that time).
-func (r *Result) Total(t time.Time) time.Duration {
-	return t.Sub(r.t0)
-}
-
 // Format formats stats result.
 func (r Result) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -97,7 +83,7 @@ func (r Result) Format(s fmt.State, verb rune) {
 			fmt.Fprintf(&buf, "Server processing: %4d ms\n",
 				int(r.ServerProcessing/time.Millisecond))
 
-			if !r.t5.IsZero() {
+			if r.total > 0 {
 				fmt.Fprintf(&buf, "Content transfer:  %4d ms\n\n",
 					int(r.contentTransfer/time.Millisecond))
 			} else {
@@ -113,7 +99,7 @@ func (r Result) Format(s fmt.State, verb rune) {
 			fmt.Fprintf(&buf, "Start Transfer: %4d ms\n",
 				int(r.StartTransfer/time.Millisecond))
 
-			if !r.t5.IsZero() {
+			if r.total > 0 {
 				fmt.Fprintf(&buf, "Total:          %4d ms\n",
 					int(r.total/time.Millisecond))
 			} else {

--- a/pre_go18.go
+++ b/pre_go18.go
@@ -24,6 +24,20 @@ func (r *Result) End(t time.Time) {
 	r.total = r.t5.Sub(r.t0)
 }
 
+// ContentTransfer returns the duration of content transfer time.
+// It is from first response byte to the given time. The time must
+// be time after read body (go-httpstat can not detect that time).
+func (r *Result) ContentTransfer(t time.Time) time.Duration {
+	return t.Sub(r.t4)
+}
+
+// Total returns the duration of total http request.
+// It is from dns lookup start time to the given time. The
+// time must be time after read body (go-httpstat can not detect that time).
+func (r *Result) Total(t time.Time) time.Duration {
+	return t.Sub(r.t0)
+}
+
 func withClientTrace(ctx context.Context, r *Result) context.Context {
 	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
 		GetConn: func(hostPort string) {


### PR DESCRIPTION
`t0-5` fields of `Result` struct aren't used after go1.8 or later, but some codes depends on them. So, the above methods don't work go1.8 or later.

I fixed them.